### PR TITLE
DAFT-6: Fix location in URL params

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,29 +53,29 @@ for listing in listings:
 To install the CLI, clone the repo and install the dependencies with `make install`.
 
 ```
-$ poetry run daft search --max-pages 1 property-for-rent
-     id    price  title                                                                       propertyType
--------  -------  --------------------------------------------------------------------------  --------------
-1443907     2800  Capital Dock Residence, Grand Canal, Grand Canal Dock, Co. Dublin           Apartments
-1446982     2500  Quayside Quarter, North Wall Quay, Dublin 1, Co. Dublin                     Apartments
-1442724     2850  Opus, 6 Hanover Quay, Hanover Quay, Dublin 2, Co. Dublin                    Apartments
-2621605     1900  Knockrabo, Mount Anville Road, Goatstown, Co. Dublin                        Apartments
-2503954     2500  OCCU Scholarstown Wood, Scholarstown Road, Rathfarnham, Co. Dublin          Apartments
-2511232     1900  Clancy Quay by Kennedy Wilson, South Circular Road, Dublin 8, Co. Dublin    Apartments
-2314852     1700  Elmfield by Havitat, Ballyogan Road, Leopardstown, Co. Dublin               Apartments
-1442430     2150  Mount Argus Apartments, Mount Argus Road, Harold's Cross, Co. Dublin        Apartments
-1491037     1950  Bridgefield, Northwood, Santry, Co. Dublin                                  Apartments
-2621761      430  Archway Court Student Accommodation, Mountjoy Street, Dublin 7, Co. Dublin  Apartments
-2524873     2200  Ropemaker Place, Hanover Street East, Dublin 2, Co. Dublin                  Apartments
-2329824     1750  Wolfe Tone Lofts by Havitat, Wolfe Tone Street, Dublin 1, Co. Dublin        Apartments
-2632723     2000  Heuston South Quarter, St Johns Road West, Dublin 8, Co. Dublin             Apartments
-1527608     2808  Node Living, 25 pembroke street upper, Dublin 2, Co. Dublin                 Apartments
-2317385     1900  Sandford Lodge by Kennedy Wilson, Sandford Lodge, Ranelagh, Co. Dublin      Apartments
-2524752     2350  Whitepines South, Stocking Avenue, Rathfarnham, Co. Dublin                  Apartments
-1518281     1850  Marina Village, Greystones, Co. Wicklow                                     Apartments
-2287912     1750  Hanbury Mews, Hanbury Lane, Dublin 8, Co. Dublin                            Apartments
-2316503     2600  Alto Vetro, Grand Canal Square, Dublin 2, Co. Dublin                        Apartments
-2317419     1800  Northbank Apartments, Castleforbes Road, Dublin 1, Co. Dublin               Apartments
+$ poetry run daft search --max-pages 1 property-for-rent --location cork --location galway
+     id    price  title                                                                    propertyType
+-------  -------  -----------------------------------------------------------------------  --------------
+2315059     3328  The Elysian, Eglinton Road, Co. Cork                                     Apartments
+2588837      570  Parchment Square, Model Farm Road, Cork, Co. Cork                        Apartments
+2310295      175  Nido Curraheen Point, Farranlea Road, Co. Cork                           Apartments
+2292251      220  From Here - Student Living, Galway Central, Fairgreen Road, Co. Galway   Apartments
+2590894      495  BUNK CO LIVING, Kiltartan house Forster Street, Co. Galway               Apartments
+2575994      650  Steelworks, 9/10 Copley Street, Ballintemple, Cork City, Cork, Co. Cork  Apartments
+2327420      237  Lee Point, South Main Street, Co. Cork                                   Apartments
+2751036     2400  16A The Long Walk, Co. Galway                                            House
+2745585     1588  Wellington Road, Co. Cork                                                Apartment
+2626561     2800  3 Saint Joseph's Terrace, Gould Street, Co. Cork                         House
+2737101     1800  CHURCHFIELDS SALTHILL, Salthill, Co. Galway                              House
+2759058     1400  24 Rutland Place, South Terrace, Co. Cork                                Apartment
+2629695     1750  56 Caiseal Cam, Roscam, Co. Galway                                       House
+2737848     1500  Dark Rd, Kilcolgan, Co. Galway                                           House
+2737834     1800  11 Shangort Park, Knocknacarra, Co. Galway                               House
+2757337      950  Apartment 3, 13 Harbour Row, Cobh, Co. Cork                              House
+2756288     4500  Meizelljob, Coast Road, Fountainstown, Co. Cork                          House
+2756231     1500  Garrai De Brun, Fort Lorenzo, Taylor's Hill, Co. Galway                  House
+2632714     1650  3 Bothar An tSlÃ©ibhe, Moycullen, Co. Galway                             House
+2750256     1900  Grealishtown, Bohermore, Co. Galway                                      House
 ```
 
 ## `search` command
@@ -89,7 +89,7 @@ For any flag that can take `[multiple]` arguments, you can supply the flag multi
 | flag  | description |
 |---|---|
 | --headers | The attributes to print out for each listing. [multiple] |
-| --locations | Which location you want to search for. For all the possible values, check out the [Location Enum](daft_scraper/search/options_location.py) [multiple] |
+| --location | Which location you want to search for. For all the possible values, check out the [Location Enum](daft_scraper/search/options_location.py) [multiple] |
 | --max-pages | Each page is 20 results, this sets the limit on the number of pages fetched. |
 | --min-price | Minimum price. |
 | --max-price | Maximum price. |

--- a/daft_scraper/cli/__init__.py
+++ b/daft_scraper/cli/__init__.py
@@ -19,7 +19,7 @@ app = typer.Typer()
 def search(
     search_type: SearchType,
     headers: List[str] = ['id', 'price', 'title', 'propertyType'],
-    locations: List[str] = [Location.ALL.value],
+    location: List[str] = [Location.ALL.value],
     max_pages: int = sys.maxsize,
     min_price: int = 0,
     max_price: int = sys.maxsize,
@@ -34,9 +34,9 @@ def search(
     sort: Sort = Sort.BEST_MATCH.value,
     furnishing: Furnishing = Furnishing.ALL_FURNISHINGS.value
 ):
-    locations = [Location(location) for location in locations]
+    location = [Location(location) for location in location]
     options = [
-        LocationsOption(locations),
+        LocationsOption(location),
         PriceOption(min_price, max_price),
         BedOption(min_beds, max_beds),
         PropertyTypesOption(property_type),

--- a/daft_scraper/search/__init__.py
+++ b/daft_scraper/search/__init__.py
@@ -32,6 +32,12 @@ class DaftSearch():
         options = self._translate_options(query)
         listings = []
 
+        # If only one location is specified, it should be in the URL, not the params
+        locations = options.get('location', [])
+        if len(locations) == 1:
+            path = path.replace('ireland', locations[0])
+            del options['location']
+
         # Init pagination params
         options['pageSize'] = self.PAGE_SIZE
         options['from'] = 0

--- a/daft_scraper/search/options_location.py
+++ b/daft_scraper/search/options_location.py
@@ -4167,5 +4167,5 @@ class LocationsOption(Option):
             return {}
 
         return {
-            "Location": [location.value for location in self.locations]
+            "location": [location.value for location in self.locations]
         }

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -38,7 +38,7 @@ class TestDaftScraper(unittest.TestCase):
         wanted = {
             'propertyType': ['apartments'],
             'facilities': ['parking', 'serviced-property'],
-            'Location': ['swords-dublin'],
+            'location': ['swords-dublin'],
             'rentalPrice_from': 0,
             'rentalPrice_to': 1000,
             'numBeds_from': 1,


### PR DESCRIPTION
When only searching for one location, the location becomes part of the URL but when you supply multiple locations, they become parameters.

* Fixes the location URL issue
* Change the CLI flag `--locations` to `--location`