### PR TITLE
DAFT-7: Fix sale price option

### DIFF
--- a/daft_scraper/search/__init__.py
+++ b/daft_scraper/search/__init__.py
@@ -6,7 +6,7 @@ from typing import List
 
 from daft_scraper import Daft
 from daft_scraper.listing import Listing
-from daft_scraper.search.options import Option
+from daft_scraper.search.options import Option, PriceOption, SalePriceOption
 
 
 class SearchType(Enum):
@@ -20,6 +20,7 @@ class SearchType(Enum):
 
 class DaftSearch():
     PAGE_SIZE = 20
+    SALE_TYPES = [SearchType.SALE, SearchType.NEW_HOMES, SearchType.COMMERCIAL_SALE]
 
     def __init__(self, search_type: SearchType):
         self.search_type = search_type
@@ -65,6 +66,10 @@ class DaftSearch():
         """Convert options into dict[str:str] form"""
         options = {}
         for option in query:
+            if isinstance(option, PriceOption) and self.search_type in self.SALE_TYPES:
+                # If the search is a sale type, translate the price option
+                option = SalePriceOption(option.min, option.max)
+
             options = {**options, **option.get_params()}
         return options
 

--- a/daft_scraper/search/options.py
+++ b/daft_scraper/search/options.py
@@ -18,8 +18,8 @@ class PriceOption(Option):
 
     def get_params(self):
         return {
-            f"{PriceOption.PARAM_KEY}_from": self.min,
-            f"{PriceOption.PARAM_KEY}_to": self.max,
+            f"{self.PARAM_KEY}_from": self.min,
+            f"{self.PARAM_KEY}_to": self.max,
         }
 
 

--- a/daft_scraper/search/options.py
+++ b/daft_scraper/search/options.py
@@ -23,6 +23,10 @@ class PriceOption(Option):
         }
 
 
+class SalePriceOption(PriceOption):
+    PARAM_KEY = "salePrice"
+
+
 @dataclass
 class BedOption(Option):
     min: int = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daft-scraper"
-version = "1.0.3"
+version = "1.0.4"
 description = "A webscraper for Daft.ie"
 authors = ["Evan Smith <me@iamevan.me>"]
 license = "MIT"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -54,6 +54,21 @@ class TestDaftScraper(unittest.TestCase):
         got = self.api._translate_options(options)
         self.assertEqual(got, wanted)
 
+    def test__translate_options__use_saleprice(self):
+        wanted = {
+            'salePrice_from': 100000,
+            'salePrice_to': 200000
+        }
+
+        sale_types = [SearchType.SALE, SearchType.NEW_HOMES, SearchType.COMMERCIAL_SALE]
+        for sale_type in sale_types:
+            api = DaftSearch(sale_type)
+            options = [
+                PriceOption(100000, 200000),
+            ]
+            got = api._translate_options(options)
+            self.assertEqual(got, wanted)
+
     def test__build_search_path(self):
         got = self.api._build_search_path()
         self.assertEqual(got, "property-for-rent/ireland")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -60,8 +60,7 @@ class TestDaftScraper(unittest.TestCase):
             'salePrice_to': 200000
         }
 
-        sale_types = [SearchType.SALE, SearchType.NEW_HOMES, SearchType.COMMERCIAL_SALE]
-        for sale_type in sale_types:
+        for sale_type in DaftSearch.SALE_TYPES:
             api = DaftSearch(sale_type)
             options = [
                 PriceOption(100000, 200000),


### PR DESCRIPTION
Sale and rental prices have different keys in the URL, so I've changed the search to automatically use the sale price key if the search is:

* For a sale
* For a commercial sale
* For a new home