### PR TITLE
DAFT-11: Misc fixes

### DIFF
--- a/daft_scraper/__init__.py
+++ b/daft_scraper/__init__.py
@@ -36,6 +36,7 @@ class Daft():
         if enable_retries:
             retry_strategy = Retry(
                 total=3,
+                status_forcelist=[500, 502, 503, 504],
                 backoff_factor=0.1
             )
             adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)

--- a/daft_scraper/listing.py
+++ b/daft_scraper/listing.py
@@ -75,7 +75,7 @@ class ListingPRS(Schema):
 
 
 class ListingSchema(Schema):
-    URL_BASE = "https://daft.ie"
+    URL_BASE = Daft.BASE_URL
     PRICE_RE = re.compile(r'[0-9,]+')
 
     class Meta:

--- a/daft_scraper/listing.py
+++ b/daft_scraper/listing.py
@@ -149,7 +149,7 @@ class Listing(dict):
 
     @property
     def description(self) -> str:
-        return self.ad_page_info['props']['pageProps']['listing'].get('description', None)
+        return self.ad_page_info['props']['pageProps'].get(listing, {}).get('description', None)
 
     @property
     def county(self) -> list:

--- a/daft_scraper/listing.py
+++ b/daft_scraper/listing.py
@@ -149,7 +149,7 @@ class Listing(dict):
 
     @property
     def description(self) -> str:
-        return self.ad_page_info['props']['pageProps'].get(listing, {}).get('description', None)
+        return self.ad_page_info['props']['pageProps'].get('listing', {}).get('description', None)
 
     @property
     def county(self) -> list:


### PR DESCRIPTION
* Sometimes the listing key doesn't exist on a page, so we need to use a safe `get`.
* Add retries for server errors.
* When making an `ad_page_info` request, it was getting 302s for the content because it was redirecting to the `www.` form of the URl - so, to fix that we change how we build the `url` attribute to use the `www.` form by default.