### PR TITLE
DAFT-12: Fix CLI info and README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ listings = api.search(options)
 
 print(len(listings))
 for listing in listings:
-    print(listing.get('title'))
+    print(getattr(listing, 'title'))
 
 ```
 

--- a/daft_scraper/cli/__init__.py
+++ b/daft_scraper/cli/__init__.py
@@ -53,7 +53,7 @@ def search(
 
     table_data = []
     for listing in listings:
-        row = [listing.get(header) for header in headers]
+        row = [getattr(listing, header, "") for header in headers]
         table_data.append(row)
 
     print(tabulate(table_data, headers=headers))


### PR DESCRIPTION
When I switched from using a raw dict schema to using an object, I forgot to update the CLI and README example. So, when you tried out the library, you'd get a list of empty info (because a safe `get` in Python just returns None).

This PR fixes #12 by:

* Changing the CLI to use `getattr` from the object
* Changing the README example to also use the `getattr` function