### PR TITLE
DAFT-14: Add new property types for sales

### DIFF
--- a/daft_scraper/search/options.py
+++ b/daft_scraper/search/options.py
@@ -60,6 +60,14 @@ class PropertyType(Enum):
     HOUSE = "houses"
     APARTMENT = "apartments"
     STUDIO_APARTMENT = "studio-apartments"
+    DETACHED_HOUSE = "detached-houses"
+    SEMI_DETACHED_HOUSE = "semi-detached-houses"
+    TERRACED_HOUSE = "terraced-houses"
+    END_OF_TERRACE_HOUSE = "end-of-terrace-houses"
+    TOWNHOUSE = "townhouses"
+    DUPLEX = "duplexes"
+    BUNGALOW = "bungalows"
+    SITE = "sites"
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daft-scraper"
-version = "1.2.6"
+version = "1.2.7"
 description = "A webscraper for Daft.ie"
 authors = ["Evan Smith <me@iamevan.me>"]
 license = "MIT"


### PR DESCRIPTION
Thanks to \#15, we know there are missing property types for the option.

Added the following property types:

* studio-apartments
* detached-houses
* semi-detached-houses
* terraced-houses
* end-of-terrace-houses
* townhouses
* duplexes
* bungalows
* sites

Closes #15 