### PR TITLE
DAFT-15: Allow an initial offset

### DIFF
--- a/daft_scraper/listing.py
+++ b/daft_scraper/listing.py
@@ -2,6 +2,7 @@ import json
 import re
 from marshmallow import Schema, fields, INCLUDE, post_load
 from marshmallow.utils import missing
+from urllib.parse import urljoin
 
 from daft_scraper import Daft
 
@@ -98,7 +99,7 @@ class ListingSchema(Schema):
         return missing
 
     def get_url(self, seo_friendly_path):
-        return "".join([self.URL_BASE, seo_friendly_path])
+        return urljoin(self.URL_BASE, seo_friendly_path)
 
     @post_load
     def post_load(self, data, **kwargs):

--- a/daft_scraper/search/__init__.py
+++ b/daft_scraper/search/__init__.py
@@ -26,7 +26,7 @@ class DaftSearch():
         self.search_type = search_type
         self.site = Daft()
 
-    def search(self, query: List[Option], max_pages: int = sys.maxsize):
+    def search(self, query: List[Option], max_pages: int = sys.maxsize, page_offset: int = 0):
         path = self._build_search_path()
 
         # Convert options to their string form
@@ -41,7 +41,7 @@ class DaftSearch():
 
         # Init pagination params
         options['pageSize'] = self.PAGE_SIZE
-        options['from'] = 0
+        options['from'] = self._calc_offset(page_offset)
 
         # Fetch the first page and get pagination info
         page_data = self._get_page_data(path, options)

--- a/daft_scraper/search/__init__.py
+++ b/daft_scraper/search/__init__.py
@@ -31,7 +31,6 @@ class DaftSearch():
 
         # Convert options to their string form
         options = self._translate_options(query)
-        listings = []
 
         # If only one location is specified, it should be in the URL, not the params
         locations = options.get('location', [])
@@ -50,13 +49,11 @@ class DaftSearch():
 
         while current_page < min(totalPages, max_pages):
             listing_data = page_data['props']['pageProps']['listings']
-            listings.extend(self._get_listings(listing_data))
+            yield from self._get_listings(listing_data)
 
             options['from'] = self._calc_offset(current_page)
             page_data = self._get_page_data(path, options)
             current_page = page_data['props']['pageProps']['paging']['currentPage']
-
-        return listings
 
     def _build_search_path(self):
         """Build the URL path for searches"""
@@ -85,10 +82,8 @@ class DaftSearch():
 
     def _get_listings(self, listings: dict):
         """Convert a dict of listings into marshalled objects"""
-        return [
-            Listing(ListingSchema().load(listing['listing']))
-            for listing in listings
-        ]
+        for listing in listings:
+            yield Listing(ListingSchema().load(listing['listing']))
 
     def _calc_offset(self, current_page: int):
         """Calculate the offset for pagination"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "daft-scraper"
-version = "1.2.7"
+version = "1.3.0"
 description = "A webscraper for Daft.ie"
 authors = ["Evan Smith <me@iamevan.me>"]
 license = "MIT"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,7 +31,7 @@ class TestDaftScraper(unittest.TestCase):
             BedOption(1, 4),
         ]
 
-        got = self.api.search(options)
+        got = list(self.api.search(options))
         self.assertEqual(got[0].id, 1443907)
 
     def test__translate_options(self):
@@ -83,7 +83,7 @@ class TestDaftScraper(unittest.TestCase):
         path = self.api._build_search_path()
         page_data = self.api._get_page_data(path, params={})
 
-        got = self.api._get_listings(page_data['props']['pageProps']['listings'])
+        got = list(self.api._get_listings(page_data['props']['pageProps']['listings']))
         self.assertEqual(got[0].id, 1443907)
 
     def test__calc_offset(self):


### PR DESCRIPTION
Fixes one minor issue: 

* The URL attribute for listings had an extra slash after the base domain

Adds a couple small QoL improvements:

* Adds a `page_offset` to `search` so you can handle pages with finer control
* Adds a `post_process_hook` so that you can use the observer pattern to handle/mutate results
* Changed to a yield pattern so that you can iterate through listing results one at a time