### PR TITLE
Fix two issues I faced when using the scraper

### DIFF
--- a/daft_scraper/__init__.py
+++ b/daft_scraper/__init__.py
@@ -8,7 +8,7 @@ class DaftHTTPSession(requests.Session):
     """
     Wrap a regular session to use a base URL and add a user-agent header
     """
-    DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Gecko/20100101 Firefox/24.0"
+    DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36"
 
     def __init__(self, prefix_url=None, user_agent=None, *args, **kwargs):
         super(DaftHTTPSession, self).__init__(*args, **kwargs)

--- a/daft_scraper/listing.py
+++ b/daft_scraper/listing.py
@@ -30,13 +30,22 @@ class Seller(Schema):
     backgroundColour = fields.Str()
 
 
+class ImageLabel(Schema):
+    label = fields.Str()
+    type = fields.Str()
+
+class ImageItem(Schema):
+    class Meta:
+        unknown = INCLUDE 
+    
+    imageLabels = fields.List(fields.Nested(ImageLabel), missing=list)
+
 class ListingMedia(Schema):
     class Meta:
-        # Include unknown fields in the deserialized output
         unknown = INCLUDE
 
-    images = fields.List(fields.Dict(keys=fields.Str(), values=fields.Str()), default=[])
-
+    images = fields.List(fields.Nested(ImageItem), default=[])
+    
     totalImages = fields.Int()
     hasVideo = fields.Bool(default=False)
     hasVirtualTour = fields.Bool(default=False)


### PR DESCRIPTION
- Update the User Agent to avoid denied issue
- Update images in ListingMedia(Schema) to mitigate the `marshmallow.exceptions.ValidationError` as daft has changed things and causing following error:

```zsh
Traceback (most recent call last):
File "/Users/myuser/Documents/daft-main/main.py", line 49, in <module>
for listing in listings:
^^^^^^^^
File "/Users/myuser/Documents/daft-main/.venv/lib/python3.12/site-packages/daft_scraper/search/init.py", line 57, in search
yield from self._get_listings(listing_data)
File "/Users/myuser/Documents/daft-main/.venv/lib/python3.12/site-packages/daft_scraper/search/init.py", line 92, in _get_listings
Listing(ListingSchema().load(listing['listing'])),
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/myuser/Documents/daft-main/.venv/lib/python3.12/site-packages/marshmallow/schema.py", line 792, in load
return self._do_load(
^^^^^^^^^^^^^^
File "/Users/myuser/Documents/daft-main/.venv/lib/python3.12/site-packages/marshmallow/schema.py", line 999, in _do_load
raise exc
marshmallow.exceptions.ValidationError: {'media': {'images': {0: defaultdict(<class 'dict'>, {'imageLabels': {'value': ['Not a valid string.']}}), 2: defaultdict(<class 'dict'>, {'imageLabels': {'value': ['Not a valid string.']}}), 4: defaultdict(<class 'dict'>, {'imageLabels': {'value': ['Not a valid string.']}})}}}
```